### PR TITLE
Add a Reset button to the move-to-bugzilla view.

### DIFF
--- a/move-to-bugzilla.js
+++ b/move-to-bugzilla.js
@@ -175,6 +175,12 @@ async function populateMoveForm(sections, pathname) {
   });
   moveButton.disabled = false;
 
+  const resetButton = document.getElementById("reset-move-form");
+  resetButton.addEventListener("click", () => {
+    section.storage.clear();
+    populateFromIssue(controls, issue);
+  });
+
   sections.show("move-form");
 }
 

--- a/move.html
+++ b/move.html
@@ -33,6 +33,7 @@
     <label for=depends-on>Depends on: </label><input id="depends-on">
     <div></div>
     <div class="actions">
+      <button id="reset-move-form">Reset</button>
       <button id="move-commit" class="primary" disabled>Move bug</button>
     </div>
   </div>


### PR DESCRIPTION
This is just a copy of the reset button for the triage view. I had a case where I had data from a pre- 51bdfecfae02dd7f6845730616e8fd136857b22f commit in the storage, and needed to clean it. But having that button all the time probably doesn't hurt.