### PR TITLE
Update recording of scores and priorities

### DIFF
--- a/bugzilla-content.js
+++ b/bugzilla-content.js
@@ -70,6 +70,8 @@ async function setBugData(data) {
     setElementValue("component", data.component, {dispatchChange: true});
   }
   setElementValue("priority", data.priority);
+  setElementValue("cf_webcompat_priority", data.webcompatPriority);
+  setElementValue("cf_performance_impact", data.performanceImpact);
   setElementValue("bug_severity", data.severity);
   setElementValue("bug_file_loc", data.url);
   setElementValue("keywords", data.keywords);

--- a/triage-report.html
+++ b/triage-report.html
@@ -213,8 +213,8 @@
           <option>P5</option>
         </select>
 
-      <li><label for="score">Score:</label>
-        <output id="score"></output>
+      <li><label for="user-impact-score">Score:</label>
+        <output id="user-impact-score"></output>
     </ul>
   </div>
 

--- a/triage-report.html
+++ b/triage-report.html
@@ -40,7 +40,6 @@
       <li>
         <div>
           <label for="rank">Site Rank: </label><output id="rank"></output>
-          <output id="rank-domain" hidden></output>
         </div>
     </ul>
 

--- a/triage-report.js
+++ b/triage-report.js
@@ -452,14 +452,28 @@ class TriageSection extends Section {
       } else {
         unsetUserStoryControls.push(...this.performanceControls);
       }
+
       const data = {
-        priority: controls.priority.value,
-        severity: controls.severity.value,
         url: controls.url.value,
         keywords: keywords.getFromControls(keywordControls, ["webcompat:site-report"]),
         userStory: userStory.getFromControls(userStoryControls, unsetUserStoryControls),
         dependsOn: getDependsOn(bugData.dependson, controls),
       };
+      if (bugData.product === "Web Compatibility") {
+        data.priority = controls.priority.value;
+        data.severity = controls.severity.value;
+        data.webcompatPriority = controls.priority.value;
+      } else if (bugData.product === "Core" && bugData.component === "Perfomance") {
+        const priorityToImpact = {
+          P1: "high",
+          P2: "medium",
+          P3: "low"
+        };
+        data.performanceImpact = priorityToImpact[controls.priority.value];
+      } else {
+        data.webcompatPriority = controls.priority.value;
+      }
+
       if (productComponent !== null) {
         [data.product, data.component] = productComponent;
       }

--- a/triage-report.js
+++ b/triage-report.js
@@ -31,6 +31,9 @@ class UserStory {
     if (control.constructor === CheckboxListControl) {
       return control.state.join(",");
     }
+    if (control.constructor === OutputControl) {
+      return control.value;
+    }
     const serializeOptionsStr = control.datasetValue("serializeOptions") || "";
     const serializeOptions = new Set(serializeOptionsStr.split(",").map(item => item.trim()));
     if (!serializeOptions.has("no-default") || control.state !== control.defaultState)  {
@@ -410,7 +413,7 @@ class TriageSection extends Section {
     });
     controls.severity = new OutputControl(state, "severity", () => severity.value.severity);
     controls.priority = new OutputControl(state, "priority", () => priority.value.priority);
-    controls.score = new OutputControl(state, "score", () => score.value);
+    controls.score = new OutputControl(state, "user-impact-score", () => score.value);
 
     const updateButton = new Button(state, "update-bug", async () => {
       updateButton.disabled = true;
@@ -426,7 +429,8 @@ class TriageSection extends Section {
                                  controls.configuration,
                                  controls.affects,
                                  controls.branch,
-                                 controls.diagnosisTeam];
+                                 controls.diagnosisTeam,
+                                 controls.score];
       const unsetUserStoryControls = [];
 
       // Only set this if we want to change the product / component

--- a/triage-report.js
+++ b/triage-report.js
@@ -396,14 +396,26 @@ class TriageSection extends Section {
       }
     });
 
-    controls.rank = new OutputControl(state, "rank", () => rank.value ? rank.value.globalRank : "null");
-    controls.rankDomain = new OutputControl(state, "rank-domain", (control) => {
-      if (rank.value) {
-        control.show();
-        return `(${rank.value.rankedDomain})`;
+    controls.rank = new OutputControl(state, "rank", () => {
+      const rankData = rank.value;
+      console.log("Setting rank", rankData);
+      const parts = [];
+      if (!rankData) {
+        return "Missing URL";
       }
-      control.hide();
-      return "";
+      if (rankData.globalRank) {
+        parts.push(`${rankData.globalRank} (global)`);
+      }
+      if (rankData.localRank && (rankData.globalRank === null || rankData.localRank < rankData.globalRank)) {
+        parts.push(`${rankData.localRank} (local)`);
+      }
+      if (!parts.length) {
+        parts.push("Unranked");
+      }
+      if (rankData.rankedDomain) {
+        parts.push(`[${rankData.rankedDomain}]`);
+      }
+      return parts.join(" ");
     });
     controls.severity = new OutputControl(state, "severity", () => severity.value.severity);
     controls.priority = new OutputControl(state, "priority", () => priority.value.priority);

--- a/ui.js
+++ b/ui.js
@@ -456,6 +456,13 @@ export class OutputControl extends UiElement {
     });
   }
 
+  get name() {
+    if(this.elem.name) {
+      return this.elem.name;
+    }
+    return this.elem.id;
+  }
+
   get value() {
     return this.elem.value;
   }


### PR DESCRIPTION
* Record the computed score in the `user-story` field
* Use a version of the CrUX data that provides both local and global ranks
* Display both global and local ranks in the UI (where appropriate)
* Set WebCompat Priority field (or Performance Impact for perf bugs)
* Switch to setting the priorities purely by score; >100 = P2 >750=P1