### PR TITLE
Set Webcompat Priority and Webcompat Score fields during triage

### DIFF
--- a/bugzilla-content.js
+++ b/bugzilla-content.js
@@ -71,6 +71,7 @@ async function setBugData(data) {
   }
   setElementValue("priority", data.priority);
   setElementValue("cf_webcompat_priority", data.webcompatPriority);
+  setElementValue("cf_webcompat_score", data.webcompatScore);
   setElementValue("cf_performance_impact", data.performanceImpact);
   setElementValue("bug_severity", data.severity);
   setElementValue("bug_file_loc", data.url);

--- a/triage-report.html
+++ b/triage-report.html
@@ -211,6 +211,25 @@
           <option>P5</option>
         </select>
 
+      <li id="webcompat-priority-control"><label for="webcompat-priority">WebCompat Priority:</label>
+        <select id="webcompat-priority">
+          <option>---</option>
+          <option>?</option>
+          <option>-</option>
+          <option>P1</option>
+          <option>P2</option>
+          <option>P3</option>
+          <option>revisit</option>
+        </select>
+
+      <li id="performance-impact-control"><label for="performance-impact">Performance Impact:</label>
+        <select id="performance-impact">
+          <option>---</option>
+          <option>high</option>
+          <option>medium</option>
+          <option>low</option>
+        </select>
+
       <li><label for="user-impact-score">Score:</label>
         <output id="user-impact-score"></output>
     </ul>

--- a/triage-report.html
+++ b/triage-report.html
@@ -19,7 +19,6 @@
     <div>
       <label for="severity-initial">Severity:</label>
       <output id="severity-initial"></output>
-
       <label for="priority-initial">Priority:</label>
       <output id="priority-initial"></output>
     </div>
@@ -59,7 +58,7 @@
       <option data-state=unsupported-feature value=80>Unsupported feature
       <option data-state=unsupported-warning value=20>Unsupported warning
       <hr>
-      <option data-state=workflow-broken value=60>Workflow broken
+      <option data-state=workflow-broken value=80>Workflow broken
       <option data-state=feature-broken value=30>Feature broken / missing
       <option data-state=feature-broken-minor value=10>Minor broken / missing feature
       <hr>

--- a/triage-report.js
+++ b/triage-report.js
@@ -486,7 +486,7 @@ class TriageSection extends Section {
         data.severity = controls.severity.value;
         data.webcompatPriority = controls.webcompatPriority.value;
         data.webcompatScore = getWebcompatScoreBucket(controls.score.value);
-      } else if (bugData.product === "Core" && bugData.component === "Perfomance") {
+      } else if (bugData.product === "Core" && bugData.component === "Performance") {
         data.performanceImpact = controls.performanceImpact.value;
       } else {
         data.webcompatPriority = controls.webcompatPriority.value;


### PR DESCRIPTION
For web compatibility bugs, set the Web Compatibility Priority and Web Compat Score fields.

Unlike Priority, Web Compatibility Priority doesn't take into account whether the bug is a regression.

Also set the Performance Impact field for performance bugs (assuming the user has the right permissions).