### PR TITLE
Supersede breakage bug tp-breakage with keyword "webcompat:tracker-blocking"

### DIFF
--- a/move-to-bugzilla.js
+++ b/move-to-bugzilla.js
@@ -195,7 +195,7 @@ class IssueForm extends Section {
     let closeMessage;
     const preconditionsHasETP = /\bETP\b/gim.test(sections.preconditions[1]);
     if (etpState === "strict") {
-      dependsOn.push("1101005");
+      keywords.push("webcompat:tracker-blocking");
       closeMessage = `Thanks for the report. I was able to reproduce the issue with Enhanced Tracking Protection set to Standard in Private Browsing Mode.
 
 Until the issue is resolved, set ETP to Off in Private Browsing  or to Standard in Normal Browsing.`;

--- a/triage-report.js
+++ b/triage-report.js
@@ -263,9 +263,9 @@ function getWebcompatScoreBucket(score) {
   return bucket;
 }
 
-function getEtpType(dependsOn) {
+function getEtpType(keywords, dependsOn) {
   const entries = dependsOn.split(",").map(item => item.trim());
-  if (entries.includes("1101005")) {
+  if (keywords.includes("webcompat:tracker-blocking")) {
     return "strict";
   }
   if (entries.includes("1480137")) {
@@ -513,7 +513,7 @@ class TriageSection extends Section {
     const controls = this.controls;
     const userStory = new UserStory(bugData.cf_user_story);
     const keywords = new Keywords(bugData.keywords);
-    const etpType = getEtpType(bugData.dependson);
+    const etpType = getEtpType(bugData.keywords, bugData.dependson);
 
     controls.url.state = bugData.url;
     controls.initialPriority.state = bugData.priority;


### PR DESCRIPTION
The keyword is defined as https://bugzilla.mozilla.org/describekeywords.cgi#:~:text=webcompat%3Atracker%2Dblocking

> A web compatibility problem caused by tracker blocking.

Which matches the definition of the meta-bug tp-breakage (Bug 1101005).

Tracking tracking-protection breakage with the meta-bug isn't suitable anymore due to the sheer amount of bugs blocking it, making bugzilla slow and spamming folks. A keyword is more suitable. We already have the component "Privacy: Site Reports" with most bugs being about tracking-protection breakage. The remaining breakage causes still block their respective meta-bug for now.

The keyword got introduced in https://bugzilla.mozilla.org/show_bug.cgi?id=1960844

Fixes #5

If desireable I could also request a keyword to supersede Bug 1480137, but would prefer to do so in a follow-up.